### PR TITLE
feat: add command coordinator and action proxy

### DIFF
--- a/Sources/Coordinators/CommandCoordinator.swift
+++ b/Sources/Coordinators/CommandCoordinator.swift
@@ -1,0 +1,38 @@
+import AppKit
+
+/// 协调标准命令，将其转发到事件总线
+final class CommandCoordinator {
+    private let events: AppEvents
+    private let proxy: ActionProxy
+
+    init(events: AppEvents = .shared) {
+        self.events = events
+        self.proxy = ActionProxy(events: events)
+    }
+
+    /// 将代理插入到 responder 链
+    func install() {
+        let app = NSApp
+        proxy.nextResponder = app.nextResponder
+        app.nextResponder = proxy
+    }
+}
+
+/// 负责截获标准动作并转发到事件总线的代理
+private final class ActionProxy: NSResponder {
+    private let events: AppEvents
+
+    init(events: AppEvents) {
+        self.events = events
+    }
+
+    override func save(_ sender: Any?) {
+        events.save.send(())
+    }
+
+    override func performTextFinderAction(_ sender: Any?) {
+        if let action = sender as? NSTextFinder.Action {
+            events.performTextFinderAction.send(action)
+        }
+    }
+}

--- a/Sources/Core/EventBus/AppEvents.swift
+++ b/Sources/Core/EventBus/AppEvents.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Combine
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// 全局应用事件总线
+final class AppEvents {
+    static let shared = AppEvents()
+
+    /// 保存动作
+    let save = PassthroughSubject<Void, Never>()
+
+    /// 文本查找相关动作
+    let performTextFinderAction = PassthroughSubject<NSTextFinder.Action, Never>()
+
+    private init() {}
+}

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -101,6 +101,10 @@ app.services = services
 let delegate = AppDelegate()
 app.delegate = delegate
 
+// 注册标准动作代理
+let commandCoordinator = CommandCoordinator()
+commandCoordinator.install()
+
 // 信号处理
 signal(SIGINT) { _ in
     print("\n👋 收到退出信号")

--- a/build.sh
+++ b/build.sh
@@ -16,11 +16,13 @@ swiftc -o "Context Collector.app/Contents/MacOS/ContextCollector" \
     Sources/Core/Protocols/StorageServiceType.swift \
     Sources/Core/Protocols/HotkeyServiceType.swift \
     Sources/Core/Protocols/PreferencesServiceType.swift \
+    Sources/Core/EventBus/AppEvents.swift \
     Sources/PreferencesService.swift \
     Sources/Infrastructure/DI/ServiceContainer.swift \
     Sources/ClipboardService.swift \
     Sources/StorageService.swift \
     Sources/HotkeyService.swift \
+    Sources/Coordinators/CommandCoordinator.swift \
     Sources/WindowManager.swift \
     Sources/Views/KeyboardNavigationHandler.swift \
     Sources/Views/ProjectSelectionView.swift \


### PR DESCRIPTION
## Summary
- add AppEvents bus for save and text finder actions
- route responder chain commands through new CommandCoordinator and ActionProxy
- wire CommandCoordinator during startup and update build script

## Testing
- `bash build.sh` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68adedd5f4b08331971a9850834f4d1e