### PR TITLE
refactor: introduce capture view model

### DIFF
--- a/Sources/Coordinators/CommandCoordinator.swift
+++ b/Sources/Coordinators/CommandCoordinator.swift
@@ -27,7 +27,7 @@ private final class ActionProxy: NSResponder {
     }
 
     override func save(_ sender: Any?) {
-        events.save.send(())
+        events.saveRequested.send(())
     }
 
     override func performTextFinderAction(_ sender: Any?) {

--- a/Sources/Coordinators/CommandCoordinator.swift
+++ b/Sources/Coordinators/CommandCoordinator.swift
@@ -1,0 +1,38 @@
+import AppKit
+
+/// 协调标准命令，将其转发到事件总线
+final class CommandCoordinator {
+    private let events: AppEvents
+    private let proxy: ActionProxy
+
+    init(events: AppEvents = .shared) {
+        self.events = events
+        self.proxy = ActionProxy(events: events)
+    }
+
+    /// 将代理插入到 responder 链
+    func install() {
+        let app = NSApp
+        proxy.nextResponder = app.nextResponder
+        app.nextResponder = proxy
+    }
+}
+
+/// 负责截获标准动作并转发到事件总线的代理
+private final class ActionProxy: NSResponder {
+    private let events: AppEvents
+
+    init(events: AppEvents) {
+        self.events = events
+    }
+
+    override func save(_ sender: Any?) {
+        events.save.send(())
+    }
+
+    override func performTextFinderAction(_ sender: Any?) {
+        if let action = sender as? NSTextFinder.Action {
+            events.performTextFinderAction.send(action)
+        }
+    }
+}

--- a/Sources/Core/EventBus/AppEvents.swift
+++ b/Sources/Core/EventBus/AppEvents.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Combine
+#if canImport(AppKit)
+import AppKit
+#endif
+
+/// 全局应用事件总线
+final class AppEvents {
+    static let shared = AppEvents()
+
+    /// 保存动作
+    let save = PassthroughSubject<Void, Never>()
+
+    /// 文本查找相关动作
+    let performTextFinderAction = PassthroughSubject<NSTextFinder.Action, Never>()
+
+    private init() {}
+}

--- a/Sources/Core/EventBus/AppEvents.swift
+++ b/Sources/Core/EventBus/AppEvents.swift
@@ -8,8 +8,8 @@ import AppKit
 final class AppEvents {
     static let shared = AppEvents()
 
-    /// 保存动作
-    let save = PassthroughSubject<Void, Never>()
+    /// 保存请求
+    let saveRequested = PassthroughSubject<Void, Never>()
 
     /// 文本查找相关动作
     let performTextFinderAction = PassthroughSubject<NSTextFinder.Action, Never>()

--- a/Sources/ViewModels/CaptureViewModel.swift
+++ b/Sources/ViewModels/CaptureViewModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Combine
+
+final class CaptureViewModel: ObservableObject {
+    private let services: ServiceContainer
+
+    @Published var title: String = "untitled"
+    @Published var content: String = ""
+    @Published var selectedProject: String?
+    @Published var projects: [String] = []
+    @Published var isLoading: Bool = false
+    @Published var showingNewProjectDialog: Bool = false
+    @Published var newProjectName: String = ""
+
+    init(services: ServiceContainer) {
+        self.services = services
+    }
+
+    func loadInitialData() {
+        projects = services.storage.getProjects()
+        let lastProject = services.storage.getLastSelectedProject()
+        if let lastProject = lastProject, projects.contains(lastProject) {
+            selectedProject = lastProject
+        } else {
+            selectedProject = nil
+        }
+        loadClipboardContent()
+    }
+
+    func loadClipboardContent() {
+        isLoading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            Thread.sleep(forTimeInterval: 0.1)
+            let clipboardText = self.services.clipboard.readClipboardText()
+            DispatchQueue.main.async {
+                self.isLoading = false
+                if let text = clipboardText, !text.isEmpty {
+                    self.content = "// 说明：\n\n\(text)"
+                } else {
+                    self.content = "// 说明：\n\n"
+                }
+            }
+        }
+    }
+
+    func saveContent() -> Bool {
+        print("💾 保存内容")
+        services.storage.saveLastSelectedProject(selectedProject)
+        if let savedPath = services.storage.saveContent(content, title: title, project: selectedProject) {
+            print("✅ 保存成功: \(savedPath.path)")
+            return true
+        } else {
+            print("❌ 保存失败")
+            return false
+        }
+    }
+
+    func createNewProject(name: String) {
+        print("📁 创建新项目: \(name)")
+        if services.storage.createProject(name: name) {
+            print("✅ 项目创建成功")
+            projects = services.storage.getProjects()
+            selectedProject = name
+        } else {
+            print("❌ 项目创建失败")
+        }
+    }
+
+    func selectProject(_ project: String?) {
+        selectedProject = project
+        print("📂 选择项目: \(project ?? "Inbox")")
+    }
+}

--- a/Sources/WindowManager.swift
+++ b/Sources/WindowManager.swift
@@ -39,8 +39,7 @@ class WindowManager: ObservableObject {
         }
         
         let captureView = CaptureWindow(
-            clipboardService: services.clipboard,
-            storageService: services.storage,
+            services: services,
             onClose: { [weak self] afterSave in self?.hideCaptureWindow(afterSave: afterSave) },
             onMinimize: { [weak self] in self?.minimizeCaptureWindow() }
         )

--- a/Sources/main.swift
+++ b/Sources/main.swift
@@ -101,6 +101,10 @@ app.services = services
 let delegate = AppDelegate()
 app.delegate = delegate
 
+// 注册标准动作代理
+let commandCoordinator = CommandCoordinator()
+commandCoordinator.install()
+
 // 信号处理
 signal(SIGINT) { _ in
     print("\n👋 收到退出信号")

--- a/build.sh
+++ b/build.sh
@@ -16,11 +16,13 @@ swiftc -o "Context Collector.app/Contents/MacOS/ContextCollector" \
     Sources/Core/Protocols/StorageServiceType.swift \
     Sources/Core/Protocols/HotkeyServiceType.swift \
     Sources/Core/Protocols/PreferencesServiceType.swift \
+    Sources/Core/EventBus/AppEvents.swift \
     Sources/PreferencesService.swift \
     Sources/Infrastructure/DI/ServiceContainer.swift \
     Sources/ClipboardService.swift \
     Sources/StorageService.swift \
     Sources/HotkeyService.swift \
+    Sources/Coordinators/CommandCoordinator.swift \
     Sources/WindowManager.swift \
     Sources/Views/KeyboardNavigationHandler.swift \
     Sources/Views/ProjectSelectionView.swift \

--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,7 @@ swiftc -o "Context Collector.app/Contents/MacOS/ContextCollector" \
     Sources/HotkeyService.swift \
     Sources/Coordinators/CommandCoordinator.swift \
     Sources/WindowManager.swift \
+    Sources/ViewModels/CaptureViewModel.swift \
     Sources/Views/KeyboardNavigationHandler.swift \
     Sources/Views/ProjectSelectionView.swift \
     Sources/Views/AdvancedTextEditor.swift \


### PR DESCRIPTION
## Summary
- create `CaptureViewModel` to own services and handle clipboard loading and saving
- wire `CaptureWindow` to `CaptureViewModel` with `@StateObject` and listen for `AppEvents.saveRequested`
- rename `AppEvents.save` to `saveRequested` and update coordinator and build script

## Testing
- `./build.sh` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68adeff6aaac833193702d07d4097816