### PR TITLE
refactor: introduce capture view model

### DIFF
--- a/Sources/Coordinators/CommandCoordinator.swift
+++ b/Sources/Coordinators/CommandCoordinator.swift
@@ -27,7 +27,7 @@ private final class ActionProxy: NSResponder {
     }
 
     override func save(_ sender: Any?) {
-        events.save.send(())
+        events.saveRequested.send(())
     }
 
     override func performTextFinderAction(_ sender: Any?) {

--- a/Sources/Core/EventBus/AppEvents.swift
+++ b/Sources/Core/EventBus/AppEvents.swift
@@ -8,8 +8,8 @@ import AppKit
 final class AppEvents {
     static let shared = AppEvents()
 
-    /// 保存动作
-    let save = PassthroughSubject<Void, Never>()
+    /// 保存请求
+    let saveRequested = PassthroughSubject<Void, Never>()
 
     /// 文本查找相关动作
     let performTextFinderAction = PassthroughSubject<NSTextFinder.Action, Never>()

--- a/Sources/ViewModels/CaptureViewModel.swift
+++ b/Sources/ViewModels/CaptureViewModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Combine
+
+final class CaptureViewModel: ObservableObject {
+    private let services: ServiceContainer
+
+    @Published var title: String = "untitled"
+    @Published var content: String = ""
+    @Published var selectedProject: String?
+    @Published var projects: [String] = []
+    @Published var isLoading: Bool = false
+    @Published var showingNewProjectDialog: Bool = false
+    @Published var newProjectName: String = ""
+
+    init(services: ServiceContainer) {
+        self.services = services
+    }
+
+    func loadInitialData() {
+        projects = services.storage.getProjects()
+        let lastProject = services.storage.getLastSelectedProject()
+        if let lastProject = lastProject, projects.contains(lastProject) {
+            selectedProject = lastProject
+        } else {
+            selectedProject = nil
+        }
+        loadClipboardContent()
+    }
+
+    func loadClipboardContent() {
+        isLoading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            Thread.sleep(forTimeInterval: 0.1)
+            let clipboardText = self.services.clipboard.readClipboardText()
+            DispatchQueue.main.async {
+                self.isLoading = false
+                if let text = clipboardText, !text.isEmpty {
+                    self.content = "// 说明：\n\n\(text)"
+                } else {
+                    self.content = "// 说明：\n\n"
+                }
+            }
+        }
+    }
+
+    func saveContent() -> Bool {
+        print("💾 保存内容")
+        services.storage.saveLastSelectedProject(selectedProject)
+        if let savedPath = services.storage.saveContent(content, title: title, project: selectedProject) {
+            print("✅ 保存成功: \(savedPath.path)")
+            return true
+        } else {
+            print("❌ 保存失败")
+            return false
+        }
+    }
+
+    func createNewProject(name: String) {
+        print("📁 创建新项目: \(name)")
+        if services.storage.createProject(name: name) {
+            print("✅ 项目创建成功")
+            projects = services.storage.getProjects()
+            selectedProject = name
+        } else {
+            print("❌ 项目创建失败")
+        }
+    }
+
+    func selectProject(_ project: String?) {
+        selectedProject = project
+        print("📂 选择项目: \(project ?? "Inbox")")
+    }
+}

--- a/Sources/WindowManager.swift
+++ b/Sources/WindowManager.swift
@@ -39,8 +39,7 @@ class WindowManager: ObservableObject {
         }
         
         let captureView = CaptureWindow(
-            clipboardService: services.clipboard,
-            storageService: services.storage,
+            services: services,
             onClose: { [weak self] afterSave in self?.hideCaptureWindow(afterSave: afterSave) },
             onMinimize: { [weak self] in self?.minimizeCaptureWindow() }
         )

--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,7 @@ swiftc -o "Context Collector.app/Contents/MacOS/ContextCollector" \
     Sources/HotkeyService.swift \
     Sources/Coordinators/CommandCoordinator.swift \
     Sources/WindowManager.swift \
+    Sources/ViewModels/CaptureViewModel.swift \
     Sources/Views/KeyboardNavigationHandler.swift \
     Sources/Views/ProjectSelectionView.swift \
     Sources/Views/AdvancedTextEditor.swift \


### PR DESCRIPTION
## Summary
- create `CaptureViewModel` to own services and handle clipboard loading and saving
- wire `CaptureWindow` to `CaptureViewModel` with `@StateObject` and listen for `AppEvents.saveRequested`
- rename `AppEvents.save` to `saveRequested` and update coordinator and build script

## Testing
- `./build.sh` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68adeff6aaac833193702d07d4097816